### PR TITLE
Greedy gesture handling, removes ctrl+click to pan

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,7 +453,8 @@ function myMap() {
     var mapCanvas = document.getElementById("map");
     var mapOptions = {
         center: center,
-        zoom: 7
+        zoom: 7,
+        gestureHandling: "greedy",
     };
 
     map = new google.maps.Map(mapCanvas, mapOptions);
@@ -474,7 +475,8 @@ function searchCity() {
 
         var mapOptions = {
             center: center,
-            zoom: 7
+            zoom: 7,
+            gestureHandling: "greedy",
         };
         map.setOptions(mapOptions);
     } else {


### PR DESCRIPTION
Fair warning, I wasn't able to test this locally, but it should work.

https://developers.google.com/maps/documentation/javascript/interaction#gesturehandling_greedy